### PR TITLE
Update pmpro-mailchimp.php

### DIFF
--- a/pmpro-mailchimp.php
+++ b/pmpro-mailchimp.php
@@ -1023,7 +1023,7 @@ function pmpromc_processSubscriptions($param) {
 }
 add_action('template_redirect', 'pmpromc_processSubscriptions', 1);
 add_filter('wp_redirect', 'pmpromc_processSubscriptions', 99);
-
+add_action('pmpro_after_change_membership_level','pmpromc_processSubscriptions',30);
 /**
  * Unsubscribe a user from a specific list
  *


### PR DESCRIPTION
This issue comes into existence when their account gets expired and our process subscription method doesn't work due to no hook present for background expiry cron. So, Just hook with the change_level hook to fix this and our same subscription process will work for background cron jobs also.